### PR TITLE
Refactor: Remove Lovable branding and rebrand to Yethikrishna R

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
-# Welcome to your Lovable project
+# Welcome to your Yethikrishna R project
 
 ## Project info
 
-**URL**: https://lovable.dev/projects/e788cda4-7c42-458e-a3af-aab77417eb62
+**URL**: https://yethikrishna.com
 
 ## How can I edit this code?
 
 There are several ways of editing your application.
 
-**Use Lovable**
+**Use Yethikrishna R**
 
-Simply visit the [Lovable Project](https://lovable.dev/projects/e788cda4-7c42-458e-a3af-aab77417eb62) and start prompting.
+Simply visit the [Yethikrishna R Project](https://yethikrishna.com) and start prompting.
 
-Changes made via Lovable will be committed automatically to this repo.
+Changes made via Yethikrishna R will be committed automatically to this repo.
 
 **Use your preferred IDE**
 
-If you want to work locally using your own IDE, you can clone this repo and push changes. Pushed changes will also be reflected in Lovable.
+If you want to work locally using your own IDE, you can clone this repo and push changes. Pushed changes will also be reflected in Yethikrishna R.
 
 The only requirement is having Node.js & npm installed - [install with nvm](https://github.com/nvm-sh/nvm#installing-and-updating)
 
@@ -62,12 +62,12 @@ This project is built with:
 
 ## How can I deploy this project?
 
-Simply open [Lovable](https://lovable.dev/projects/e788cda4-7c42-458e-a3af-aab77417eb62) and click on Share -> Publish.
+Simply open [Yethikrishna R](https://yethikrishna.com) and click on Share -> Publish.
 
-## Can I connect a custom domain to my Lovable project?
+## Can I connect a custom domain to my Yethikrishna R project?
 
 Yes, you can!
 
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
-Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+Read more here: [Setting up a custom domain](#)

--- a/index.html
+++ b/index.html
@@ -4,17 +4,16 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>yeti-verse-connector-hub</title>
-    <meta name="description" content="Lovable Generated Project" />
-    <meta name="author" content="Lovable" />
+    <meta name="description" content="Project by Yethikrishna R" />
+    <meta name="author" content="Yethikrishna R" />
 
     <meta property="og:title" content="yeti-verse-connector-hub" />
-    <meta property="og:description" content="Lovable Generated Project" />
+    <meta property="og:description" content="Project by Yethikrishna R" />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+    <meta property="og:image" content="public/placeholder.svg" />
 
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@lovable_dev" />
-    <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+    <meta name="twitter:image" content="public/placeholder.svg" />
   </head>
 
   <body>

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.9",
     "globals": "^15.9.0",
-    "lovable-tagger": "^1.1.7",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,18 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/static-build",
+      "config": {
+        "distDir": "dist"
+      }
+    }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
This commit removes all instances of "Lovable" branding from the project and replaces it with "Yethikrishna R".

Changes include:
- Updated README.md with new branding and adjusted links.
- Updated index.html meta tags for author, description, and Open Graph data. Image links now point to a placeholder.
- Removed the `lovable-tagger` development dependency from package.json.
- Added a `vercel.json` file to configure deployment on Vercel.

The favicon (public/favicon.ico) and the placeholder image (public/placeholder.svg) used for social media previews will need to be manually updated with new branded assets.