### PR TITLE
Refactor: Handle missing Clerk publishable key gracefully

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,11 +14,19 @@ const queryClient = new QueryClient();
 
 const PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
 
-if (!PUBLISHABLE_KEY) {
-  throw new Error("Missing Publishable Key");
-}
+// The early throw new Error for missing PUBLISHABLE_KEY has been removed from here.
 
 function App() {
+  if (!PUBLISHABLE_KEY) {
+    return (
+      <div style={{ padding: '20px', textAlign: 'center', fontFamily: 'sans-serif', color: 'red' }}>
+        <h1>Configuration Error</h1>
+        <p>The application is missing a required configuration (VITE_CLERK_PUBLISHABLE_KEY).</p>
+        <p>Please ensure this environment variable is set.</p>
+      </div>
+    );
+  }
+
   return (
     <ClerkProvider publishableKey={PUBLISHABLE_KEY}>
       <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
I've modified src/App.tsx to display a user-friendly error message if the VITE_CLERK_PUBLISHABLE_KEY environment variable is not set. Previously, a missing key would cause an immediate crash at module initialization, leading to a blank screen.

This change does not fix the underlying need for the environment variable to be set but improves the application's robustness by providing clearer feedback on this specific configuration issue.

The primary resolution remains for you to ensure
VITE_CLERK_PUBLISHABLE_KEY is correctly configured in the deployment environment.